### PR TITLE
Update ffi and sass-embedded to the latest versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,16 +3,19 @@ GEM
   specs:
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    bigdecimal (3.1.8)
     colorator (1.1.0)
     concurrent-ruby (1.2.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.13.1)
+    ffi (1.17.0)
     foreman (0.87.2)
     forwardable-extended (2.6.0)
-    google-protobuf (3.22.0)
+    google-protobuf (4.28.2)
+      bigdecimal
+      rake (>= 13)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -50,16 +53,16 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.1)
-    rake (13.0.6)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (4.1.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.58.3)
-      google-protobuf (~> 3.21)
-      rake (>= 10.0.0)
+    sass-embedded (1.79.4)
+      google-protobuf (~> 4.27)
+      rake (>= 13)
     sassc (2.4.0)
       ffi (~> 1.9)
     terminal-table (3.0.2)
@@ -77,4 +80,4 @@ DEPENDENCIES
   sassc (>= 2.3.0)
 
 BUNDLED WITH
-   2.2.22
+   2.5.21


### PR DESCRIPTION
They did not compile on my Mac (possibly newer ARM machines) so I updated them. I also updated bundler since it started showing a deprecation wearning (guess who added this and it's me):

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```